### PR TITLE
feat: Include Makefiles from all cloned components

### DIFF
--- a/linkfiles/Makefile
+++ b/linkfiles/Makefile
@@ -1,0 +1,1 @@
+include $(COMPONENTS_DIR)/**/tasks/**/Makefile


### PR DESCRIPTION
Allows Makefiles cloned from various component repositories to be automatically included in the Make scope at the top of the repo. Must be included via manifest to make any impact.